### PR TITLE
Fix dangerous SQL detection

### DIFF
--- a/dist/database.js
+++ b/dist/database.js
@@ -154,13 +154,8 @@ export class DatabaseManager {
      * 检查是否为危险的查询操作
      */
     isDangerousQuery(query) {
-        const dangerousKeywords = [
-            'DROP', 'DELETE', 'UPDATE', 'INSERT', 'ALTER',
-            'TRUNCATE', 'CREATE', 'REPLACE', 'LOAD', 'IMPORT'
-        ];
-        const upperQuery = query.toUpperCase().trim();
-        return dangerousKeywords.some(keyword => upperQuery.startsWith(keyword + ' ') ||
-            upperQuery.includes(' ' + keyword + ' '));
+        const dangerousPattern = /\b(DROP|DELETE|UPDATE|INSERT|ALTER|TRUNCATE|CREATE|REPLACE|LOAD|IMPORT)\b/i;
+        return dangerousPattern.test(query.trim());
     }
     /**
      * 验证表名是否合法

--- a/src/database.ts
+++ b/src/database.ts
@@ -174,16 +174,8 @@ export class DatabaseManager {
    * 检查是否为危险的查询操作
    */
   private isDangerousQuery(query: string): boolean {
-    const dangerousKeywords = [
-      'DROP', 'DELETE', 'UPDATE', 'INSERT', 'ALTER', 
-      'TRUNCATE', 'CREATE', 'REPLACE', 'LOAD', 'IMPORT'
-    ];
-    
-    const upperQuery = query.toUpperCase().trim();
-    return dangerousKeywords.some(keyword => 
-      upperQuery.startsWith(keyword + ' ') || 
-      upperQuery.includes(' ' + keyword + ' ')
-    );
+    const dangerousPattern = /\b(DROP|DELETE|UPDATE|INSERT|ALTER|TRUNCATE|CREATE|REPLACE|LOAD|IMPORT)\b/i;
+    return dangerousPattern.test(query.trim());
   }
 
   /**


### PR DESCRIPTION
## Summary
- improve SQL validation by using regex to detect dangerous statements

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842ba30e9608326ab7ce0e7b5f11bb6